### PR TITLE
publish wheels

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -36,7 +36,7 @@ jobs:
         pip install pytest pytest-cov
         pytest
     - name: Build package
-      run: python -m build --sdist
+      run: python -m build
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:


### PR DESCRIPTION
reverts 81c92446487f1232d5da0ce18225eeb102c774cd

the commit message does not give much away about what the intention of that one was, but it is preferable to publish a wheel rather than make every user build their own